### PR TITLE
Gitignore pkg and src

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/pkg/
+/src/
 *.deb
 *.tar
 *.tar.zst


### PR DESCRIPTION
This prevents them from showing up in a `git status` after a build